### PR TITLE
Update libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'com.github.johnrengelman.shadow' version '5.2.0'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.71'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.21'
     id 'maven-publish'
     id "com.github.ben-manes.versions" version "0.28.0"
     id "com.wynprice.cursemaven" version "2.1.1"
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'org.cultofclang.minecraft'
-version '1.3.71'
+version '1.5.21'
 
 if (System.getenv("GITHUB_RUN_NUMBER")!=null) {
     version += "-" + System.getenv("GITHUB_RUN_NUMBER")
@@ -21,7 +21,7 @@ else{
 
 repositories {
     mavenCentral()
-    jcenter()
+
     maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
 
     maven {
@@ -37,12 +37,12 @@ dependencies {
     compileOnly 'org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT'
     yum "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0"
     yum "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    yum "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.3.5"
+    yum "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.5.1"
     yum "org.nield:kotlin-statistics:1.2.1"
-    yum "com.charleskorn.kaml:kaml:0.17.0"
-    yum "org.jetbrains.exposed:exposed-dao:0.23.1"
-    yum "org.jetbrains.exposed:exposed-jdbc:0.23.1"
-    yum "org.xerial:sqlite-jdbc:3.30.1"
+    yum "com.charleskorn.kaml:kaml:0.35.0"
+    yum "org.jetbrains.exposed:exposed-dao:0.32.1"
+    yum "org.jetbrains.exposed:exposed-jdbc:0.32.1"
+    yum "org.xerial:sqlite-jdbc:3.36.0.1"
 }
 
 processResources {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri Mar 13 14:10:50 PDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update libraries, theses changes are for the server I made as I use a more recent version of Kotlin on there

I removed `jcenter()` because the service closed, but thankfully all libraries have migrated to maven central

Also I had to update Gradle to use the latest version of Kotlin, as it require at least Gradle 6.1.1
